### PR TITLE
Remove GRETAP and switch to vxlan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gluon-mesh-vpn-wireguard
+# gluon-mesh-vpn-wireguard-vxlan
 
 You can use this package for connecting with wireguard to the Freifunk Munich network.
 
@@ -34,6 +34,5 @@ You should use something like the following in the site.conf:
         
 ```    
 
-**The `mcastgroup` is the one of the server(s)!**
 
 And you should include the package in the site.mk of course!

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You should use something like the following in the site.conf:
         
 ```
  mesh_vpn = {
-        mtu = 1410,
+        mtu = 1400,
         wireguard = {
                 enabled = 'true',
                 iface = 'mesh-vpn',

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You should use something like the following in the site.conf:
                 iface = 'mesh-vpn',
                 iprange = '10.3', --must be a /16!!
                 limit = '1', -- actually unused
-                gretapip = '10.3.0.2',
+                mcastgroup = '239.1.1.1',
                 peers = {
                                 {
                                         publickey ='N9uF5Gg1B5AqWrE9IuvDgzmQePhqhb8Em/HrRpAdnlY=',
@@ -33,6 +33,6 @@ You should use something like the following in the site.conf:
         
 ```    
 
-**The `gretatpip` is the one of the server(s)!**
+**The `mcastgroup` is the one of the server(s)!**
 
 And you should include the package in the site.mk of course!

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ You should use something like the following in the site.conf:
                 enabled = 'true',
                 iface = 'mesh-vpn',
                 limit = '1', -- actually unused
-                mcastgroup = 'ff02::15c',
                 peers = {
                                 {
                                         publickey ='N9uF5Gg1B5AqWrE9IuvDgzmQePhqhb8Em/HrRpAdnlY=',

--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
 # gluon-mesh-vpn-wireguard
 
-You can use this package for connecting with wireguard to the freifunk Königswinter network.
+You can use this package for connecting with wireguard to the Freifunk Munich network.
 
 You should use something like the following in the site.conf:
 
         
 ```
  mesh_vpn = {
-        mtu = 1420,
+        mtu = 1410,
         wireguard = {
                 enabled = 'true',
                 iface = 'mesh-vpn',
-                iprange = '10.3', --must be a /16!!
                 limit = '1', -- actually unused
                 mcastgroup = '239.1.1.1',
                 peers = {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You should use something like the following in the site.conf:
                 enabled = 'true',
                 iface = 'mesh-vpn',
                 limit = '1', -- actually unused
-                mcastgroup = '239.1.1.1',
+                mcastgroup = 'ff02::15c',
                 peers = {
                                 {
                                         publickey ='N9uF5Gg1B5AqWrE9IuvDgzmQePhqhb8Em/HrRpAdnlY=',

--- a/README.md
+++ b/README.md
@@ -17,14 +17,17 @@ You should use something like the following in the site.conf:
                                 {
                                         publickey ='N9uF5Gg1B5AqWrE9IuvDgzmQePhqhb8Em/HrRpAdnlY=',
                                         endpoint ='ffkwsn01.freifunk-koenigswinter.de:30020',
+                                        link_address = 'fe80::f000:22ff:fe12:01',
                                 },                
                                 {
                                         publickey ='liatbdT62FbPiDPHKBqXVzrEo6hc5oO5tmEKDMhMTlU=',
                                         endpoint ='ffkwsn02.freifunk-koenigswinter.de:30020',
+                                        link_address = 'fe80::f000:22ff:fe12:02',
                                 },
                                 {
                                         publickey ='xakSGG39D1v90j3Z9eVWzojh6nDbnsVUc/RByVdcKB0=',
                                         endpoint ='ffkwsn03.freifunk-koenigswinter.de:30020',
+                                        link_address = 'fe80::f000:22ff:fe12:07',
                                 },
 
                         },

--- a/gluon-mesh-vpn-wireguard/Makefile
+++ b/gluon-mesh-vpn-wireguard/Makefile
@@ -11,7 +11,7 @@ define Package/gluon-mesh-vpn-wireguard
   SECTION:=gluon
   CATEGORY:=Gluon
   TITLE:=Support for connecting meshes via wireguard
-  DEPENDS:=+gluon-mesh-vpn-core +gluon-config-mode-core +micrond +kmod-wireguard +wireguard-tools +kmod-udptunnel4 +curl +ca-bundle +ip-full
+  DEPENDS:=+gluon-mesh-vpn-core +gluon-config-mode-core +micrond +kmod-wireguard +wireguard-tools +curl +ca-bundle +ip-full
 endef
 
 define Build/Prepare

--- a/gluon-mesh-vpn-wireguard/Makefile
+++ b/gluon-mesh-vpn-wireguard/Makefile
@@ -11,7 +11,7 @@ define Package/gluon-mesh-vpn-wireguard
   SECTION:=gluon
   CATEGORY:=Gluon
   TITLE:=Support for connecting meshes via wireguard
-  DEPENDS:=+gluon-mesh-vpn-core +gluon-config-mode-core +micrond +kmod-gre +kmod-wireguard +wireguard-tools +kmod-udptunnel4 +curl +ca-bundle +ip-full
+  DEPENDS:=+gluon-mesh-vpn-core +gluon-config-mode-core +micrond +kmod-wireguard +wireguard-tools +kmod-udptunnel4 +curl +ca-bundle +ip-full
 endef
 
 define Build/Prepare

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 interface_linklocal() {
-        local macaddr="echo $(date;head -n2 /dev/urandom) |md5sum|sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/'"
+        local macaddr="$(echo $(date;head -n2 /dev/urandom) |md5sum|sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/')"
         local oldIFS="$IFS"; IFS=':'; set -- $macaddr; IFS="$oldIFS"
 
         echo "fe80::$(xor2 "$1")$2:$3ff:fe$4:$5$6"

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -22,17 +22,17 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
                 CONNECTED=0
         fi
 
-        # Gretapinterface vorhanden??
+        # VXLAN Interface vorhanden??
         if [ $CONNECTED != 0 ]; then
-                ip addr show dev gre > /dev/null
+                ip addr show dev vxlan-wan > /dev/null
                 if [ $? != 0 ]; then
                         CONNECTED=0
                 fi
         fi
 
-        # Funktioniert das Gretapinterface ueberhaupt? Also gehen Daten rueber?
+        # Funktioniert das VXLAN Interface ueberhaupt? Also gehen Daten rueber?
         if [ $CONNECTED != 0 ]; then
-                RXBYTES=$(ip -statistics link show dev gre |  sed '4q;d' | awk '{print $1}')
+                RXBYTES=$(ip -statistics link show dev vxlan-wan |  sed '4q;d' | awk '{print $1}')
                 if [ $RXBYTES == 0 ]; then
                         CONNECTED=0
                 fi
@@ -40,7 +40,7 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
 
         # Und funktioniert das Wireguardinterface? Kann ich den Server erreichen?
         if [ $CONNECTED != 0 ]; then
-                ping -c1 -w2  $(uci get wireguard.wireguard.gretapip)
+                ping -c1 -w2  $(uci get wireguard.wireguard.mcastgroup)
                 if [ $? != 0 ]; then
                         CONNECTED=0
                 fi
@@ -86,8 +86,8 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
                                                                                                  
 		#Die alten peers loeschen
 		wg set $INTERFACE peer  $(wg |  awk 'BEGIN {RS=""} /endpoint/ {print $2}') remove
-                batctl if del gre
-                ip link delete dev gre
+                batctl if del vxlan-wan
+                ip link delete dev vxlan-wan
                 ip link delete dev $INTERFACE
                 PUBLICKEY=$(uci get wireguard.wireguard.privatekey | wg pubkey)
                 echo $(uci get wireguard.wireguard.privatekey) > /tmp/wgpriv
@@ -95,18 +95,17 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
                 # Public Key zum vorher ausgesuchten Server hochladen
                 IP=$(curl -s -k --data-urlencode "pubkey=$PUBLICKEY" https://$URL/wireguard.php)
 		ip link add dev $INTERFACE type wireguard
-                ip address add dev $INTERFACE $IP/16
                 wg set $INTERFACE private-key /tmp/wgpriv
                 sleep 5
 
-                wg set $INTERFACE peer $(uci get wireguard.peer_$AUSWAHL.publickey) persistent-keepalive 25 allowed-ips $(uci get wireguard.wireguard.gretapip)/32 endpoint $(uci get wireguard.peer_$AUSWAHL.endpoint)
+                wg set $INTERFACE peer $(uci get wireguard.peer_$AUSWAHL.publickey) persistent-keepalive 25 allowed-ips $(uci get wireguard.wireguard.mcastgroup)/32 endpoint $(uci get wireguard.peer_$AUSWAHL.endpoint)
                 ip link set up dev $INTERFACE
 
                 sleep 5
-                ip link add gre type gretap local $IP remote $(uci get wireguard.wireguard.gretapip)
-                ip link set up dev gre
+                ip link add vxlan-wan type vxlan id "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vxlan", 3), 16))')" group $(uci get wireguard.wireguard.mcastgroup) dstport 4789 dev $INTERFACE
+                ip link set up dev vxlan-wan
                 sleep 5
-                batctl if add gre
+                batctl if add vxlan-wan
                 iptables -A INPUT -i $INTERFACE -j ACCEPT
                 iptables -A FORWARD -i $INTERFACE -j ACCEPT
 

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -48,7 +48,7 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
 
         # Und funktioniert das Wireguardinterface? Kann ich den Server erreichen?
         if [ $CONNECTED != 0 ]; then
-                ping -c1 -w2  $(uci get wireguard.wireguard.mcastgroup)%$INTERFACE
+                ping -c1 -w2  $(wg  | grep fe80 | cut -d'/' -f1 | awk '{print $3}')%$INTERFACE
                 if [ $? != 0 ]; then
                         CONNECTED=0
                 fi

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -114,8 +114,8 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
                 ip link set up dev vxlan-wan
                 sleep 5
                 batctl if add vxlan-wan
-                iptables -A INPUT -i $INTERFACE -j ACCEPT
-                iptables -A FORWARD -i $INTERFACE -j ACCEPT
+                ip6tables -A INPUT -i $INTERFACE -j ACCEPT
+                ip6tables -A FORWARD -i $INTERFACE -j ACCEPT
 
         fi
 fi

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -84,7 +84,7 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
                 ip address add "$(interface_linklocal "$INTERFACE")"/64 dev $INTERFACE
 
                 sleep 5
-                ip link add vxlan-wan type vxlan id "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vxlan", 3), 16))')" group $(uci get wireguard.wireguard.mcastgroup) dstport 4789 dev $INTERFACE
+                ip link add vxlan-wan type vxlan id "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vxlan", 3), 16))')" remote $(uci get uci get wireguard.peer_$PEER.link_address) dstport 4789 dev $INTERFACE
                 ip link set up dev vxlan-wan
                 sleep 5
                 batctl if add vxlan-wan

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -59,37 +59,11 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
 		# Falls ein Fehler bei Wireguard war, Module entladen und neuladen
 		rmmod wireguard
 		sleep 1
-		modprobe wireguard
+		modprobe wireguard                                                       
 
-        	#Wieviele Hosts gibts denn in der Config?                                                          
-        	MAX=10                                                                                             
-        	ANZAHL=0                                                                                           
-        	AUSWAHL=0                                                                                          
-       	 	until [ $ANZAHL -eq $MAX ]                                                                         
-       	 	do                                                                                                 
-                	ANZAHL=`expr $ANZAHL + 1`                                                                  
-                	uci show wireguard.peer_$ANZAHL 2>/dev/null > /dev/null                                    
-                	if [ $? != 0 ]; then                                                                       
-                        	break                                                                              
-                	fi                                                                                         
-        	done                                                                                               
-        	ANZAHL=`expr $ANZAHL - 1`                                                                          
-                                                                                                           
-        	#Und welchen nehmen wir jetzt??                                                                    
-        	SPEED1=0                                                                                           
-        	I=0                                                                                                
-        	until [ $I -eq $ANZAHL ]                                                                           
-        	do                                                                                                 
-                	I=`expr $I + 1`                                                                            
-                	#Von allen Servern die durschnittliche potenzielle Geschwindigkeit pro Wireguard-Verbindung
-                	URL=$(uci get wireguard.peer_$I.endpoint | cut -d':' -f1)                        
-			SPEED2=$(curl https://$URL/speed.php -k)                                           
-                	if [ $SPEED2 -gt $SPEED1 ]              # Wenn aktueller Server hoehren Wert hat,
-                        		then AUSWAHL=$I                 # Servernummer speichern                 
-                        	SPEED1=$SPEED2                                                           
-                	fi                                                                               
-        	done                                                                                     
-        	URL=$(uci get wireguard.peer_$AUSWAHL.endpoint | cut -d':' -f1)                          
+                NUMBER_OF_PEERS=$(uci show wireguard | egrep -e peer_[0-9].endpoint | wc -l)
+                PEER=awk 'BEGIN{srand();print int(rand()*($NUMBER_OF_PEERS)+1) }'
+        	URL=$(uci get wireguard.peer_$PEER.endpoint | cut -d':' -f1)                          
                                                                                                  
 		#Die alten peers loeschen
 		wg set $INTERFACE peer  $(wg |  awk 'BEGIN {RS=""} /endpoint/ {print $2}') remove
@@ -100,14 +74,14 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
                 echo $(uci get wireguard.wireguard.privatekey) > /tmp/wgpriv
 
                 # Public Key zum vorher ausgesuchten Server hochladen
-                curl -s -k --data-urlencode "pubkey=$PUBLICKEY" https://$URL/wireguard.php
+                #curl -s -k --data-urlencode "pubkey=$PUBLICKEY" https://$URL/wireguard.php
 		ip link add dev $INTERFACE type wireguard
                 wg set $INTERFACE private-key /tmp/wgpriv
                 sleep 5
 
-                wg set $INTERFACE peer $(uci get wireguard.peer_$AUSWAHL.publickey) persistent-keepalive 25 allowed-ips fe80::/10,$(uci get wireguard.wireguard.mcastgroup)/32 endpoint $(uci get wireguard.peer_$AUSWAHL.endpoint)
+                wg set $INTERFACE peer $(uci get wireguard.peer_$PEER.publickey) persistent-keepalive 25 allowed-ips fe80::/10,$(uci get wireguard.wireguard.mcastgroup)/32 endpoint $(uci get wireguard.peer_$PEER.endpoint)
                 ip link set up dev $INTERFACE
-                ip address add "$(interface_linklocal "$INTERFACE")" dev $INTERFACE
+                ip address add "$(interface_linklocal "$INTERFACE")"/64 dev $INTERFACE
 
                 sleep 5
                 ip link add vxlan-wan type vxlan id "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vxlan", 3), 16))')" group $(uci get wireguard.wireguard.mcastgroup) dstport 4789 dev $INTERFACE

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -59,20 +59,15 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
         fi
 	
         # Wenn die Tests fehlgeschlagen sind, neu connecten
-        if [ $CONNECTED == 0 ]; then
-		# Falls ein Fehler bei Wireguard war, Module entladen und neuladen
-		rmmod wireguard
-		sleep 1
-		modprobe wireguard                                                       
+        if [ $CONNECTED == 0 ]; then                                    
 
                 NUMBER_OF_PEERS=$(uci show wireguard | egrep -ce peer_[0-9].endpoint)
                 PEER=$(awk 'BEGIN{srand();print int(rand()*($NUMBER_OF_PEERS)+1) }')
-                                                                                                 
-		#Die alten peers loeschen
-		wg set $INTERFACE peer  $(wg |  awk 'BEGIN {RS=""} /endpoint/ {print $2}') remove
-                batctl if del vx_mesh_vpn
+
+                # Delete Interfaces
+                ip link set nomaster bat0 dev vx_mesh_vpn
                 ip link delete dev vx_mesh_vpn
-                ip link delete dev $INTERFACE
+                ip link del $INTERFACE
                 PUBLICKEY=$(uci get wireguard.wireguard.privatekey | wg pubkey)
                 echo $(uci get wireguard.wireguard.privatekey) > /tmp/wgpriv
 
@@ -80,16 +75,14 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
                 #curl -s -k --data-urlencode "pubkey=$PUBLICKEY" https://$URL/wireguard.php
 		ip link add dev $INTERFACE type wireguard
                 wg set $INTERFACE private-key /tmp/wgpriv
-                sleep 5
-
-                gluon-wan wg set $INTERFACE peer $(uci get wireguard.peer_$PEER.publickey) persistent-keepalive 25 allowed-ips $(uci get uci get wireguard.peer_$PEER.link_address)/128 endpoint $(uci get wireguard.peer_$PEER.endpoint)
                 ip link set up dev $INTERFACE
-                ip address add "$(interface_linklocal "$INTERFACE")"/64 dev $INTERFACE
 
-                sleep 5
+                ip address add "$(interface_linklocal "$INTERFACE")"/64 dev $INTERFACE
+                gluon-wan wg set $INTERFACE peer $(uci get wireguard.peer_$PEER.publickey) persistent-keepalive 25 allowed-ips $(uci get uci get wireguard.peer_$PEER.link_address)/128 endpoint $(uci get wireguard.peer_$PEER.endpoint)
+
                 ip link add vx_mesh_vpn type vxlan id "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vxlan", 3), 16))')" remote $(uci get uci get wireguard.peer_$PEER.link_address) dstport 4789 dev $INTERFACE
                 ip link set up dev vx_mesh_vpn
-                sleep 5
-                batctl if add vx_mesh_vpn
+
+                ip link set master bat0 dev vx_mesh_vpn
         fi
 fi

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -1,10 +1,11 @@
 #!/bin/sh
 
 interface_linklocal() {
-        local macaddr="$(echo $(date;head -n2 /dev/urandom) |md5sum|sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/')"
+        # We generate a predictable v6 address
+        local macaddr="$(echo $(uci get wireguard.wireguard.privatekey | wg pubkey) |md5sum|sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/')"
         local oldIFS="$IFS"; IFS=':'; set -- $macaddr; IFS="$oldIFS"
 
-        echo "fe80::$(xor2 "$1")$2:$3ff:fe$4:$5$6"
+        echo "fe80::$1$2:$3ff:fe$4:$5$6"
 }
 
 #Wurde bereits ein privatekey generiert?

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -63,7 +63,6 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
 
                 NUMBER_OF_PEERS=$(uci show wireguard | egrep -e peer_[0-9].endpoint | wc -l)
                 PEER=awk 'BEGIN{srand();print int(rand()*($NUMBER_OF_PEERS)+1) }'
-        	URL=$(uci get wireguard.peer_$PEER.endpoint | cut -d':' -f1)                          
                                                                                                  
 		#Die alten peers loeschen
 		wg set $INTERFACE peer  $(wg |  awk 'BEGIN {RS=""} /endpoint/ {print $2}') remove

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -47,7 +47,7 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
 
         # Und funktioniert das Wireguardinterface? Kann ich den Server erreichen?
         if [ $CONNECTED != 0 ]; then
-                ping -c1 -w2  $(uci get wireguard.wireguard.mcastgroup)
+                ping -c1 -w2  $(uci get wireguard.wireguard.mcastgroup)%$INTERFACE
                 if [ $? != 0 ]; then
                         CONNECTED=0
                 fi

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -1,10 +1,15 @@
 #!/bin/sh
 
+xor2() {
+        echo -n "${1:0:1}"
+        echo -n "${1:1:1}" | tr '0123456789abcdef' '23016745ab89efcd'
+}
+
 interface_linklocal() {
         # We generate a predictable v6 address
         local macaddr="$(echo $(uci get wireguard.wireguard.privatekey | wg pubkey) |md5sum|sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/')"
         local oldIFS="$IFS"; IFS=':'; set -- $macaddr; IFS="$oldIFS"
-        echo "fe80::$1$2:$3ff:fe$4:$5$6"
+        echo "fe80::$(xor2 "$1")$2:$3ff:fe$4:$5$6"
 }
 
 #Wurde bereits ein privatekey generiert?

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 interface_linklocal() {
-        local macaddr="$(ubus call network.device status '{"name": "'"$1"'"}' | jsonfilter -e '@.macaddr')"
+        local macaddr="echo $(date;head -n2 /dev/urandom) |md5sum|sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/'"
         local oldIFS="$IFS"; IFS=':'; set -- $macaddr; IFS="$oldIFS"
 
         echo "fe80::$(xor2 "$1")$2:$3ff:fe$4:$5$6"

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -105,7 +105,7 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
                 wg set $INTERFACE private-key /tmp/wgpriv
                 sleep 5
 
-                wg set $INTERFACE peer $(uci get wireguard.peer_$AUSWAHL.publickey) persistent-keepalive 25 allowed-ips $(uci get wireguard.wireguard.mcastgroup)/32 endpoint $(uci get wireguard.peer_$AUSWAHL.endpoint)
+                wg set $INTERFACE peer $(uci get wireguard.peer_$AUSWAHL.publickey) persistent-keepalive 25 allowed-ips fe80::/10,$(uci get wireguard.wireguard.mcastgroup)/32 endpoint $(uci get wireguard.peer_$AUSWAHL.endpoint)
                 ip link set up dev $INTERFACE
                 ip address add "$(interface_linklocal "$INTERFACE")" dev $INTERFACE
 

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -79,7 +79,7 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
                 wg set $INTERFACE private-key /tmp/wgpriv
                 sleep 5
 
-                wg set $INTERFACE peer $(uci get wireguard.peer_$PEER.publickey) persistent-keepalive 25 allowed-ips fe80::/10,$(uci get wireguard.wireguard.mcastgroup)/128 endpoint $(uci get wireguard.peer_$PEER.endpoint)
+                wg set $INTERFACE peer $(uci get wireguard.peer_$PEER.publickey) persistent-keepalive 25 allowed-ips $(uci get uci get wireguard.peer_$PEER.link_address)/128 endpoint $(uci get wireguard.peer_$PEER.endpoint)
                 ip link set up dev $INTERFACE
                 ip address add "$(interface_linklocal "$INTERFACE")"/64 dev $INTERFACE
 

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -4,7 +4,6 @@ interface_linklocal() {
         # We generate a predictable v6 address
         local macaddr="$(echo $(uci get wireguard.wireguard.privatekey | wg pubkey) |md5sum|sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/')"
         local oldIFS="$IFS"; IFS=':'; set -- $macaddr; IFS="$oldIFS"
-
         echo "fe80::$1$2:$3ff:fe$4:$5$6"
 }
 
@@ -56,7 +55,6 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
 	
         # Wenn die Tests fehlgeschlagen sind, neu connecten
         if [ $CONNECTED == 0 ]; then
-
 		# Falls ein Fehler bei Wireguard war, Module entladen und neuladen
 		rmmod wireguard
 		sleep 1
@@ -79,7 +77,7 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
                 wg set $INTERFACE private-key /tmp/wgpriv
                 sleep 5
 
-                wg set $INTERFACE peer $(uci get wireguard.peer_$PEER.publickey) persistent-keepalive 25 allowed-ips $(uci get uci get wireguard.peer_$PEER.link_address)/128 endpoint $(uci get wireguard.peer_$PEER.endpoint)
+                gluon-wan wg set $INTERFACE peer $(uci get wireguard.peer_$PEER.publickey) persistent-keepalive 25 allowed-ips $(uci get uci get wireguard.peer_$PEER.link_address)/128 endpoint $(uci get wireguard.peer_$PEER.endpoint)
                 ip link set up dev $INTERFACE
                 ip address add "$(interface_linklocal "$INTERFACE")"/64 dev $INTERFACE
 

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -62,7 +62,7 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
 		sleep 1
 		modprobe wireguard                                                       
 
-                NUMBER_OF_PEERS=$(uci show wireguard | egrep -e peer_[0-9].endpoint | wc -l)
+                NUMBER_OF_PEERS=$(uci show wireguard | egrep -ce peer_[0-9].endpoint)
                 PEER=$(awk 'BEGIN{srand();print int(rand()*($NUMBER_OF_PEERS)+1) }')
                                                                                                  
 		#Die alten peers loeschen
@@ -88,8 +88,5 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
                 ip link set up dev vx_mesh_vpn
                 sleep 5
                 batctl if add vx_mesh_vpn
-                ip6tables -A INPUT -i $INTERFACE -j ACCEPT
-                ip6tables -A FORWARD -i $INTERFACE -j ACCEPT
-
         fi
 fi

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -62,7 +62,7 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
 		modprobe wireguard                                                       
 
                 NUMBER_OF_PEERS=$(uci show wireguard | egrep -e peer_[0-9].endpoint | wc -l)
-                PEER=awk 'BEGIN{srand();print int(rand()*($NUMBER_OF_PEERS)+1) }'
+                PEER=$(awk 'BEGIN{srand();print int(rand()*($NUMBER_OF_PEERS)+1) }')
                                                                                                  
 		#Die alten peers loeschen
 		wg set $INTERFACE peer  $(wg |  awk 'BEGIN {RS=""} /endpoint/ {print $2}') remove
@@ -78,7 +78,7 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
                 wg set $INTERFACE private-key /tmp/wgpriv
                 sleep 5
 
-                wg set $INTERFACE peer $(uci get wireguard.peer_$PEER.publickey) persistent-keepalive 25 allowed-ips fe80::/10,$(uci get wireguard.wireguard.mcastgroup)/32 endpoint $(uci get wireguard.peer_$PEER.endpoint)
+                wg set $INTERFACE peer $(uci get wireguard.peer_$PEER.publickey) persistent-keepalive 25 allowed-ips fe80::/10,$(uci get wireguard.wireguard.mcastgroup)/128 endpoint $(uci get wireguard.peer_$PEER.endpoint)
                 ip link set up dev $INTERFACE
                 ip address add "$(interface_linklocal "$INTERFACE")"/64 dev $INTERFACE
 

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+interface_linklocal() {
+        local macaddr="$(ubus call network.device status '{"name": "'"$1"'"}' | jsonfilter -e '@.macaddr')"
+        local oldIFS="$IFS"; IFS=':'; set -- $macaddr; IFS="$oldIFS"
+
+        echo "fe80::$(xor2 "$1")$2:$3ff:fe$4:$5$6"
+}
+
 #Wurde bereits ein privatekey generiert?
 temp=$(uci get wireguard.wireguard.privatekey);
 #Falls nicht, wird das hier nachgeholt
@@ -93,13 +100,14 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
                 echo $(uci get wireguard.wireguard.privatekey) > /tmp/wgpriv
 
                 # Public Key zum vorher ausgesuchten Server hochladen
-                IP=$(curl -s -k --data-urlencode "pubkey=$PUBLICKEY" https://$URL/wireguard.php)
+                curl -s -k --data-urlencode "pubkey=$PUBLICKEY" https://$URL/wireguard.php
 		ip link add dev $INTERFACE type wireguard
                 wg set $INTERFACE private-key /tmp/wgpriv
                 sleep 5
 
                 wg set $INTERFACE peer $(uci get wireguard.peer_$AUSWAHL.publickey) persistent-keepalive 25 allowed-ips $(uci get wireguard.wireguard.mcastgroup)/32 endpoint $(uci get wireguard.peer_$AUSWAHL.endpoint)
                 ip link set up dev $INTERFACE
+                ip address add "$(interface_linklocal "$INTERFACE")" dev $INTERFACE
 
                 sleep 5
                 ip link add vxlan-wan type vxlan id "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vxlan", 3), 16))')" group $(uci get wireguard.wireguard.mcastgroup) dstport 4789 dev $INTERFACE

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/gluon-mesh-wireguard/checkuplink
@@ -32,7 +32,7 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
 
         # VXLAN Interface vorhanden??
         if [ $CONNECTED != 0 ]; then
-                ip addr show dev vxlan-wan > /dev/null
+                ip addr show dev vx_mesh_vpn > /dev/null
                 if [ $? != 0 ]; then
                         CONNECTED=0
                 fi
@@ -40,7 +40,7 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
 
         # Funktioniert das VXLAN Interface ueberhaupt? Also gehen Daten rueber?
         if [ $CONNECTED != 0 ]; then
-                RXBYTES=$(ip -statistics link show dev vxlan-wan |  sed '4q;d' | awk '{print $1}')
+                RXBYTES=$(ip -statistics link show dev vx_mesh_vpn |  sed '4q;d' | awk '{print $1}')
                 if [ $RXBYTES == 0 ]; then
                         CONNECTED=0
                 fi
@@ -67,8 +67,8 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
                                                                                                  
 		#Die alten peers loeschen
 		wg set $INTERFACE peer  $(wg |  awk 'BEGIN {RS=""} /endpoint/ {print $2}') remove
-                batctl if del vxlan-wan
-                ip link delete dev vxlan-wan
+                batctl if del vx_mesh_vpn
+                ip link delete dev vx_mesh_vpn
                 ip link delete dev $INTERFACE
                 PUBLICKEY=$(uci get wireguard.wireguard.privatekey | wg pubkey)
                 echo $(uci get wireguard.wireguard.privatekey) > /tmp/wgpriv
@@ -84,10 +84,10 @@ if [ "$(uci get wireguard.wireguard.enabled)" == "true" ] || [ "$(uci get wiregu
                 ip address add "$(interface_linklocal "$INTERFACE")"/64 dev $INTERFACE
 
                 sleep 5
-                ip link add vxlan-wan type vxlan id "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vxlan", 3), 16))')" remote $(uci get uci get wireguard.peer_$PEER.link_address) dstport 4789 dev $INTERFACE
-                ip link set up dev vxlan-wan
+                ip link add vx_mesh_vpn type vxlan id "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vxlan", 3), 16))')" remote $(uci get uci get wireguard.peer_$PEER.link_address) dstport 4789 dev $INTERFACE
+                ip link set up dev vx_mesh_vpn
                 sleep 5
-                batctl if add vxlan-wan
+                batctl if add vx_mesh_vpn
                 ip6tables -A INPUT -i $INTERFACE -j ACCEPT
                 ip6tables -A FORWARD -i $INTERFACE -j ACCEPT
 

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/upgrade/400-mesh-vpn-wireguard
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/upgrade/400-mesh-vpn-wireguard
@@ -17,7 +17,6 @@ fi
 
 uci set wireguard.wireguard.enabled=$(jsonfilter -i $datei -e "$.mesh_vpn.wireguard.enabled")
 uci set wireguard.wireguard.iface=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.iface")   
-uci set wireguard.wireguard.iprange=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.iprange")                                         
 uci set wireguard.wireguard.limit=$(jsonfilter -i $datei -e "$.mesh_vpn.wireguard.limit")     
 uci set wireguard.wireguard.mcastgroup=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.mcastgroup")
                                                                                                 

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/upgrade/400-mesh-vpn-wireguard
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/upgrade/400-mesh-vpn-wireguard
@@ -30,7 +30,7 @@ do
         uci set wireguard.peer_$(expr $i + 1)=peer
         uci set wireguard.peer_$(expr $i + 1).endpoint=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.peers[$i].endpoint")
         uci set wireguard.peer_$(expr $i + 1).publickey=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.peers[$i].publickey")
-        uci set wireguard.peer_$(expr $i + 1).publickey=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.peers[$i].link_address")
+        uci set wireguard.peer_$(expr $i + 1).link_address=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.peers[$i].link_address")
         i=`expr $i + 1`                                                                                                       
 done                                                                                                                          
                                                                                                                               

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/upgrade/400-mesh-vpn-wireguard
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/upgrade/400-mesh-vpn-wireguard
@@ -19,6 +19,7 @@ uci set wireguard.wireguard.enabled=$(jsonfilter -i $datei -e "$.mesh_vpn.wiregu
 uci set wireguard.wireguard.iface=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.iface")   
 uci set wireguard.wireguard.limit=$(jsonfilter -i $datei -e "$.mesh_vpn.wireguard.limit")     
 uci set wireguard.wireguard.mcastgroup=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.mcastgroup")
+
                                                                                                 
 #Wieviele peers haben wir denn?                                                                 
 anzahl=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.peers.*" | wc -l)                       
@@ -30,6 +31,7 @@ do
         uci set wireguard.peer_$(expr $i + 1)=peer
         uci set wireguard.peer_$(expr $i + 1).endpoint=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.peers[$i].endpoint")
         uci set wireguard.peer_$(expr $i + 1).publickey=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.peers[$i].publickey")
+        uci set wireguard.peer_$(expr $i + 1).publickey=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.peers[$i].link_address")
         i=`expr $i + 1`                                                                                                       
 done                                                                                                                          
                                                                                                                               

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/upgrade/400-mesh-vpn-wireguard
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/upgrade/400-mesh-vpn-wireguard
@@ -18,7 +18,7 @@ fi
 uci set wireguard.wireguard.enabled=$(jsonfilter -i $datei -e "$.mesh_vpn.wireguard.enabled")
 uci set wireguard.wireguard.iface=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.iface")   
 uci set wireguard.wireguard.limit=$(jsonfilter -i $datei -e "$.mesh_vpn.wireguard.limit")     
-
+uci set wireguard.wireguard.privkey=$(jsonfilter -i $datei -e "$.mesh_vpn.wireguard.privkey")
                                                                                                 
 #Wieviele peers haben wir denn?                                                                 
 anzahl=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.peers.*" | wc -l)                       

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/upgrade/400-mesh-vpn-wireguard
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/upgrade/400-mesh-vpn-wireguard
@@ -19,7 +19,7 @@ uci set wireguard.wireguard.enabled=$(jsonfilter -i $datei -e "$.mesh_vpn.wiregu
 uci set wireguard.wireguard.iface=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.iface")   
 uci set wireguard.wireguard.iprange=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.iprange")                                         
 uci set wireguard.wireguard.limit=$(jsonfilter -i $datei -e "$.mesh_vpn.wireguard.limit")     
-uci set wireguard.wireguard.gretapip=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.gretapip")
+uci set wireguard.wireguard.mcastgroup=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.mcastgroup")
                                                                                                 
 #Wieviele peers haben wir denn?                                                                 
 anzahl=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.peers.*" | wc -l)                       

--- a/gluon-mesh-vpn-wireguard/files/lib/gluon/upgrade/400-mesh-vpn-wireguard
+++ b/gluon-mesh-vpn-wireguard/files/lib/gluon/upgrade/400-mesh-vpn-wireguard
@@ -18,7 +18,6 @@ fi
 uci set wireguard.wireguard.enabled=$(jsonfilter -i $datei -e "$.mesh_vpn.wireguard.enabled")
 uci set wireguard.wireguard.iface=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.iface")   
 uci set wireguard.wireguard.limit=$(jsonfilter -i $datei -e "$.mesh_vpn.wireguard.limit")     
-uci set wireguard.wireguard.mcastgroup=$(jsonfilter -i $datei  -e "$.mesh_vpn.wireguard.mcastgroup")
 
                                                                                                 
 #Wieviele peers haben wir denn?                                                                 


### PR DESCRIPTION
This will hopefully add Wireguard capability to our Gluon. 

It uses VXLAN Multicast flooding to discover the VXLAN peers. Thus we don't need any configuration magic on the gateway or node side to make L2 connectivity possible. 

We completely rely on auto-generated IPv6 addresses thus also no v4 space is wasted to make it work.

Then we run BATMAN over it.

#### Not tested yet

How much overhead did we add by using vxlan instead of GRETap are we significant slower? What happens with many nodes?

#### Prototype works so far:

```
root@aw-maisach-offloader:~# batctl n
[B.A.T.M.A.N. adv openwrt-2019.2-7, MainIF/MAC: primary0/82:c5:af:37:0b:3b (bat0/52:54:00:3b:c2:82 BATMAN_V)]
IF             Neighbor              last-seen
32:a2:55:d8:96:97    0.060s (        1.0) [ vxlan-wan]
root@aw-maisach-offloader:~# wg
interface: mesh-vpn
  public key: fZ1Xc8o33qjlXkMupHcWkC1rOm5eH3rLFthlNqsiqV0=
  private key: (hidden)
  listening port: 37977

peer: aGU87gipgHLG/TvjrWrt/u/ikyoinRBHS9/fTuA84z0=
  endpoint: 195.30.193.34:40011
  allowed ips: fe80::/10, ff02::/32
  latest handshake: 1 minute, 20 seconds ago
  transfer: 39.12 KiB received, 27.11 KiB sent
  persistent keepalive: every 25 seconds
```

```
vpn01.in.ffmuc.net:~# ip -6 nei | grep bat
fe80::5054:ff:fe3b:c282 dev bat0 lladdr 52:54:00:3b:c2:82 REACHABLE
```

#### Issues

DNS resolution seems to be broken and only IPs work as wireguard endpoints not sure why ... maybe someone has an idea.

And to make this actually work we have work to do on the gateway side of the infra. As we use VRFs it's not simple to add WG to our setup. So we can either get rid of the VRF on the Gateways or use separate Gateways for WireGuard which we connect to the fastd Gateways.

Instead of the VRF we could just run the gateways totally isolated and for necessary services connect them via Nebula.

Maybe @rotanid also has some comments on this as well as @mweinelt. Maybe we can even make this upstream compatible or at least a community module.